### PR TITLE
Add IsWarmup field

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="sv">
   <head>
     <meta charset="UTF-8" />

--- a/sass/layout/_forms.scss
+++ b/sass/layout/_forms.scss
@@ -35,3 +35,13 @@
     }
   }
 }
+
+.label--checkbox {
+  margin: 0.4em 0;
+  display: flex;
+  align-items: center;
+
+  input {
+    width: auto;
+  }
+}

--- a/src/components/__test__/__snapshots__/fields.test.jsx.snap
+++ b/src/components/__test__/__snapshots__/fields.test.jsx.snap
@@ -30,6 +30,22 @@ Array [
 ]
 `;
 
+exports[`IsWarmupField renders correctly 1`] = `
+<label
+  class="label--checkbox"
+  htmlFor="isWarmup"
+>
+  <input
+    checked={true}
+    id="isWarmup"
+    onChange={[Function]}
+    type="checkbox"
+    value={false}
+  />
+  Uppvärmningsset
+</label>
+`;
+
 exports[`NameField renders correctly 1`] = `
 Array [
   <label

--- a/src/components/__test__/fields.test.jsx
+++ b/src/components/__test__/fields.test.jsx
@@ -5,7 +5,8 @@ import {
   NameField,
   RatingField,
   RepsField,
-  WeightField
+  WeightField,
+  IsWarmupField,
 } from "../fields";
 
 describe("ExerciseField", () => {
@@ -15,7 +16,7 @@ describe("ExerciseField", () => {
         <ExerciseField
           value={"Bänkpress"}
           choices={["Bänkpress", "Marklyft", "Knäböj"]}
-          handleOnChange={() => {}}
+          handleOnChange={() => { }}
         />
       )
       .toJSON();
@@ -28,7 +29,7 @@ describe("NameField", () => {
   it("renders correctly", () => {
     const tree = renderer
       .create(
-        <NameField value={"Bänkpress Boogie 1.1"} handleOnChange={() => {}} />
+        <NameField value={"Bänkpress Boogie 1.1"} handleOnChange={() => { }} />
       )
       .toJSON();
 
@@ -39,7 +40,7 @@ describe("NameField", () => {
 describe("RatingField", () => {
   it("renders correctly", () => {
     const tree = renderer
-      .create(<RatingField value={3} handleOnChange={() => {}} />)
+      .create(<RatingField value={3} handleOnChange={() => { }} />)
       .toJSON();
 
     expect(tree).toMatchSnapshot();
@@ -49,7 +50,7 @@ describe("RatingField", () => {
 describe("RepsField", () => {
   it("renders correctly", () => {
     const tree = renderer
-      .create(<RepsField value={5} handleOnChange={() => {}} />)
+      .create(<RepsField value={5} handleOnChange={() => { }} />)
       .toJSON();
 
     expect(tree).toMatchSnapshot();
@@ -59,7 +60,19 @@ describe("RepsField", () => {
 describe("WeightField", () => {
   it("renders correctly", () => {
     const tree = renderer
-      .create(<WeightField value={100} handleOnChange={() => {}} />)
+      .create(<WeightField value={100} handleOnChange={() => { }} />)
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});
+
+describe("IsWarmupField", () => {
+  it("renders correctly", () => {
+    const tree = renderer
+      .create(
+        <IsWarmupField value={true} handleOnChange={() => { }} />
+      )
       .toJSON();
 
     expect(tree).toMatchSnapshot();

--- a/src/components/fields.jsx
+++ b/src/components/fields.jsx
@@ -91,6 +91,22 @@ export const WeightField = props => {
   );
 };
 
+export const IsWarmupField = props => {
+  const { handleOnChange, value } = props;
+  return (
+    <label class="label--checkbox" htmlFor="isWarmup">
+      <input
+        type="checkbox"
+        onChange={handleOnChange}
+        checked={value}
+        value={false}
+        id="isWarmup"
+      />
+      Uppvärmningsset
+    </label>
+  );
+};
+
 export const WeightRepsFields = props => {
   const { handleOnChange, reps, weight } = props;
   return (

--- a/src/components/set-form.jsx
+++ b/src/components/set-form.jsx
@@ -6,8 +6,12 @@ export default props => {
   const { exercise, reps, rating, weight } = draft;
 
   const handleOnChange = evt => {
-    const { id: attr, value } = evt.target;
-    updateDraft(attr, value);
+    const { id: attr, value, checked, type } = evt.target;
+    if (type === "checkbox") {
+      updateDraft(attr, checked);
+    } else {
+      updateDraft(attr, value);
+    }
   };
 
   const handleOnSubmit = evt => {

--- a/src/components/set-form.jsx
+++ b/src/components/set-form.jsx
@@ -1,9 +1,14 @@
 import React from "react";
-import { ExerciseField, RatingField, WeightRepsFields } from "./fields";
+import {
+  ExerciseField,
+  RatingField,
+  WeightRepsFields,
+  IsWarmupField
+} from "./fields";
 
 export default props => {
   const { draft, updateDraft, createSet, exercises } = props;
-  const { exercise, reps, rating, weight } = draft;
+  const { exercise, reps, rating, weight, isWarmpup } = draft;
 
   const handleOnChange = evt => {
     const { id: attr, value, checked, type } = evt.target;
@@ -33,6 +38,7 @@ export default props => {
         weight={weight}
         handleOnChange={handleOnChange}
       />
+      <IsWarmupField value={isWarmpup} handleOnChange={handleOnChange} />
       <RatingField value={rating} handleOnChange={handleOnChange} />
       <div className="form-actions">
         <button type="submit">Spara</button>

--- a/src/reducers/draft.js
+++ b/src/reducers/draft.js
@@ -8,7 +8,8 @@ export const emptyDraft = () => ({
   reps: 5,
   rating: 3,
   weight: 20,
-  doneAt: d2s(new Date())
+  doneAt: d2s(new Date()),
+  isWarmup: false
 });
 
 export default (currentState = emptyDraft(), action) => {


### PR DESCRIPTION
**Why?** Sometimes it is useful to be able to log warmup sets as well as true workout sets: may it be a new workout routine that needs tweaking, or maybe it is good to track how certain warmup routines coincide with really great workout sets. It would be nice to *mark these sets as warmup sets* to skip them in statistics and to sort them out visually.

This PR fixes this.

 * Checkbox is added to Set form. 
 * Default value: unchecked.